### PR TITLE
zephyr-openthread-rcp: Support nrf52840dk-nrf52840 machine

### DIFF
--- a/meta-zephyr-core/recipes-kernel/zephyr-kernel/zephyr-openthread-rcp.bb
+++ b/meta-zephyr-core/recipes-kernel/zephyr-kernel/zephyr-openthread-rcp.bb
@@ -7,4 +7,4 @@ EXTRA_OECMAKE += "-DCONF_FILE="prj.conf overlay-rcp.conf overlay-usb-nrf-br.conf
 # The overlay config and OpenThread itself imposes some specific requirements
 # towards the boards (e.g. flash layout and ieee802154 radio) so we need to
 # limit to known working machines here.
-COMPATIBLE_MACHINE = "(arduino-nano-33-ble)"
+COMPATIBLE_MACHINE = "(arduino-nano-33-ble|nrf52840dk-nrf52840)"


### PR DESCRIPTION
This Nordic reference design can be a fallback option for Oniro's gateway-blueprint
I've been tested it myself along my single arduino-nano node

Origin: https://gitlab.eclipse.org/eclipse/oniro-core/meta-zephyr/-/merge_requests/22
Relate-to: https://gitlab.eclipse.org/eclipse/oniro-blueprints/transparent-gateway/meta-oniro-blueprints-gateway/-/issues/6
Signed-off-by: Philippe Coval <philippe.coval@astrolabe.coop>